### PR TITLE
feat(api): FastAPI 端点 + 懒加载模型（ja↔en）

### DIFF
--- a/app/infer.py
+++ b/app/infer.py
@@ -1,0 +1,31 @@
+from typing import Dict
+from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
+import torch
+
+MODEL_MAP: Dict[str, str] = {
+    "ja-en": "Helsinki-NLP/opus-mt-ja-en",
+    "en-ja": "Helsinki-NLP/opus-mt-en-ja",
+}
+
+_tok: Dict[str, AutoTokenizer] = {}
+_mod: Dict[str, AutoModelForSeq2SeqLM] = {}
+
+def _ensure(direction: str):
+    if direction not in MODEL_MAP:
+        raise ValueError(f"Unsupported direction: {direction}")
+    if direction not in _tok or direction not in _mod:
+        name = MODEL_MAP[direction]
+        _tok[direction] = AutoTokenizer.from_pretrained(name, use_safetensors=True)
+        _mod[direction] = AutoModelForSeq2SeqLM.from_pretrained(name, use_safetensors=True)
+
+def translate(text: str, direction: str = "ja-en", max_new_tokens: int = 128) -> str:
+    text = (text or "").strip()
+    if not text:
+        return ""
+    _ensure(direction)
+    tok = _tok[direction]
+    mod = _mod[direction]
+    inputs = tok(text, return_tensors="pt", truncation=True)
+    with torch.no_grad():
+        out = mod.generate(**inputs, max_new_tokens=max_new_tokens, num_beams=4)
+    return tok.decode(out[0], skip_special_tokens=True)

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,36 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+from .infer import translate
+
+app = FastAPI(title="Kyoto NMT API", version="0.1.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=False,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+class TranslateReq(BaseModel):
+    text: str = Field(..., description="要翻译的文本")
+    direction: str = Field("ja-en", pattern="^(ja-en|en-ja)$")
+    max_new_tokens: int = Field(128, ge=8, le=256)
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+@app.post("/translate")
+def translate_api(req: TranslateReq):
+    return {"translation": translate(req.text, req.direction, req.max_new_tokens)}
+
+# 也可提供固定路径，方便前端调用
+@app.post("/translate/ja-en")
+def ja_en(req: TranslateReq):
+    return {"translation": translate(req.text, direction="ja-en", max_new_tokens=req.max_new_tokens)}
+
+@app.post("/translate/en-ja")
+def en_ja(req: TranslateReq):
+    return {"translation": translate(req.text, direction="en-ja", max_new_tokens=req.max_new_tokens)}


### PR DESCRIPTION
What
- 新增 FastAPI /translate API，支持 ja→en / en→ja
- 懒加载 + safetensors，首次请求加载模型，后续更快
- CORS 允许本地前端调用

How to test
1) conda activate kyoto-nmt
2) uvicorn app.main:app --reload --host 127.0.0.1 --port 8000
3) 打开 http://127.0.0.1:8000/docs，调用 POST /translate